### PR TITLE
path for tokens only

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,9 +143,9 @@ These parameters are required in order to swap on CurveFi:
 - `expected`: Expected amount of `toToken` after the swap
 
 Here is how we forge router params:
-- `path`: `[fromToken, pool, toToken]` pool address needs to be calculated off-chain for better rate
+- `path`: `[fromToken, toToken]` fromToken and toToken address
 - `amounts`: `[amount, expected]` if calculated receiving amount less than `expected` transaction will be reversed.
-- `address`: Optional
+- `address`: `[pool]` pool address of the CurveFi pool needs to be calculated off-chain for better rate
 - `data`: Optional
 
 **note**: CurveFi only works with [sETH](https://etherscan.io/address/0x5e74C9036fb86BD7eCdcb084a0673EFc32eA31cb)

--- a/contracts/DePayRouterV1CurveFiSwap01.sol
+++ b/contracts/DePayRouterV1CurveFiSwap01.sol
@@ -39,9 +39,9 @@ contract DePayRouterV1CurveFiSwap01 {
 
   // Swap tokenA<>tokenB, ETH<>sETH or sETH<>ETH on CureFi.
   //
-  // path -> [from, pool, to]
+  // path -> [from, to]
   // amounts -> [amount, expected]
-  // addresses -> []
+  // addresses -> [pool]
   //
   //  function exchange(
   //      address _pool,      # Pool address, could able to get from 
@@ -71,18 +71,18 @@ contract DePayRouterV1CurveFiSwap01 {
     // From token is ETH, 
     if(path[0] == ETH) {
       ICurveFiSwap(CurveFiSwap).exchange{value: amounts[0]}(
-        path[1],      // pool
+        addresses[0], // pool
         path[0],      // from token
-        path[2],      // to token
+        path[1],      // to token
         amounts[0],   // amount
         amounts[1],   // expected
         address(this) // receiver
       );
     } else {
       ICurveFiSwap(CurveFiSwap).exchange(
-        path[1],      // pool
+        addresses[0], // pool
         path[0],      // from token
-        path[2],      // to token
+        path[1],      // to token
         amounts[0],   // amount
         amounts[1],   // expected
         address(this) // receiver

--- a/test/DePayRouterV1CurveFiSwap01.spec.ts
+++ b/test/DePayRouterV1CurveFiSwap01.spec.ts
@@ -51,9 +51,9 @@ describe('DePayRouterV1 + DePayRouterV1CurveFiSwap01', () => {
       routerFunc({
         router,
         wallet: ownerWallet,
-        path: [fromToken.address, curveFiPoolMock.address, toToken.address],
+        path: [fromToken.address, toToken.address],
         amounts: [1000, 1000],
-        addresses: [],
+        addresses: [curveFiPoolMock.address],
         plugins: [curveFiPlugin.address]
       })
     ).to.changeTokenBalance(toToken, router, 1000)
@@ -68,9 +68,9 @@ describe('DePayRouterV1 + DePayRouterV1CurveFiSwap01', () => {
       routerFunc({
         router,
         wallet: ownerWallet,
-        path: [fromToken.address, curveFiPoolMock.address, toToken.address],
+        path: [fromToken.address, toToken.address],
         amounts: [1000, 1000],
-        addresses: [otherWallet.address],
+        addresses: [curveFiPoolMock.address, otherWallet.address],
         plugins: [curveFiPlugin.address, paymentPlugin.address]
       })
     ).to.changeTokenBalance(toToken, otherWallet, 1000)


### PR DESCRIPTION
Missed in the main PR for curve.

Would like to keep path for token addresses only and move all other kind of addresses to "addresses".